### PR TITLE
Removed version endpoint from app.js

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+    pull_request:
+      branches: [main]
+      types: [opened, synchronize]
 
 jobs: 
   simple_deployment_pipeline:

--- a/app.js
+++ b/app.js
@@ -11,10 +11,6 @@ app.get('/health', (req,res) => {
   res.send('ok')
 })
 
-app.get('/version', (req,res) => {
-  res.send('1') //Change this string to ensure a new version deployed
-})
-
 app.listen(PORT, () => {
   // eslint-disable-next-line no-console
   console.log(`Server running on port ${PORT}`)


### PR DESCRIPTION
Here is the description of the new edit in app.js, with screenshot and useful information

- Removed version endpoint from the app.js file for checking the health of CI , only /health endpoint will be used. 